### PR TITLE
CI整備: lint, typecheck, test, build の4ジョブ並列実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run format:check
+      - run: pnpm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test:run
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ dist/
 .env
 .DS_Store
 *.log
+*.tsbuildinfo
 coverage/
 _legacy/

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "author": "butaosuinu",
   "license": "MIT",
+  "packageManager": "pnpm@10.28.2",
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,9 +21,5 @@
       "@/*": ["src/renderer/src/*"]
     }
   },
-  "include": ["src"],
-  "references": [
-    { "path": "./tsconfig.node.json" },
-    { "path": "./tsconfig.web.json" }
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- GitHub Actions CI ワークフローを追加（`.github/workflows/ci.yml`）
- `master` への push / PR をトリガーに lint, typecheck, test, build の4ジョブを並列実行
- `tsconfig.json` の `references` を削除して `tsc --noEmit` が正常動作するよう修正
- `packageManager` フィールドを `package.json` に追加（pnpm バージョン自動検出用）
- `.gitignore` に `*.tsbuildinfo` を追加

## Test plan
- [x] `pnpm run check` がローカルで通過
- [x] `pnpm run typecheck` がローカルで通過
- [x] `pnpm run build` がローカルで通過
- [ ] GitHub Actions の4ジョブがすべて成功

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)