### PR TITLE
Expand trash icons from 3 to 12 categories with Japanese labels

### DIFF
--- a/src/main/services/geminiService.ts
+++ b/src/main/services/geminiService.ts
@@ -16,15 +16,19 @@ const EXTRACTION_PROMPT = `これは日本の自治体が配布しているゴ�
 {
   "version": 2,
   "entries": [
-    { "trash": { "name": "燃えるゴミ", "icon": "" }, "rule": { "type": "weekly", "dayOfWeek": 2 } },
-    { "trash": { "name": "資源ゴミ", "icon": "" }, "rule": { "type": "nthWeekday", "dayOfWeek": 3, "weekNumbers": [1, 3] } },
-    { "trash": { "name": "粗大ゴミ", "icon": "" }, "rule": { "type": "specificDates", "dates": ["2026-03-15", "2026-04-19"] } }
+    { "trash": { "name": "燃えるゴミ", "icon": "burn" }, "rule": { "type": "weekly", "dayOfWeek": 2 } },
+    { "trash": { "name": "資源ゴミ", "icon": "recycle" }, "rule": { "type": "nthWeekday", "dayOfWeek": 3, "weekNumbers": [1, 3] } },
+    { "trash": { "name": "粗大ゴミ", "icon": "oversized" }, "rule": { "type": "specificDates", "dates": ["2026-03-15", "2026-04-19"] } }
   ]
 }
 
 注意:
 - nameにはゴミの種類を日本語で記載してください
-- iconは空文字列のままにしてください
+- iconには以下のキーから最も適切なものを設定してください:
+  burn=燃えるゴミ/可燃ゴミ, nonburn=燃えないゴミ/不燃ゴミ, recycle=資源ゴミ/リサイクル,
+  plastic=プラスチック/プラ容器, bottle=ビン/ガラスびん, can=缶/アルミ缶/スチール缶,
+  paper=古紙/新聞/雑誌/ダンボール, cloth=古布/衣類, oversized=粗大ゴミ/大型ゴミ,
+  hazardous=有害ゴミ/蛍光管/水銀, battery=乾電池/電池, other=上記に該当しないもの
 - 同じゴミの種類が複数の曜日で回収される場合、曜日ごとに別エントリーにしてください
 - JSONのみを返し、説明は不要です`;
 

--- a/src/renderer/src/components/settings/ScheduleEditor.tsx
+++ b/src/renderer/src/components/settings/ScheduleEditor.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useSchedule } from "../../hooks/useSchedule";
-import { TRASH_ICONS, SAVE_FEEDBACK_DELAY_MS } from "../../constants/schedule";
+import { TRASH_ICONS, TRASH_ICON_LABELS, SAVE_FEEDBACK_DELAY_MS } from "../../constants/schedule";
 import type { ScheduleEntry, ScheduleRule } from "../../types/schedule";
 import { SCHEDULE_VERSION } from "../../types/schedule";
 import { RuleEditor } from "./RuleEditor";
@@ -102,7 +102,7 @@ function EntryRow({ entry, onNameChange, onIconChange, onRuleChange, onRemove }:
         >
           {ICON_OPTIONS.map((iconKey) => (
             <option key={iconKey} value={iconKey}>
-              {iconKey === "" ? "なし" : `${TRASH_ICONS[iconKey]} ${iconKey}`}
+              {iconKey === "" ? "なし" : `${TRASH_ICONS[iconKey]} ${TRASH_ICON_LABELS[iconKey]}`}
             </option>
           ))}
         </select>

--- a/src/renderer/src/constants/schedule.ts
+++ b/src/renderer/src/constants/schedule.ts
@@ -10,8 +10,32 @@ export const DAY_NAMES = [
 
 export const TRASH_ICONS: Record<string, string> = {
   burn: "🔥",
+  nonburn: "🗑️",
   recycle: "♻️",
+  plastic: "🧴",
   bottle: "🍾",
+  can: "🥫",
+  paper: "📰",
+  cloth: "👕",
+  oversized: "🛋️",
+  hazardous: "⚠️",
+  battery: "🔋",
+  other: "📦",
+};
+
+export const TRASH_ICON_LABELS: Record<string, string> = {
+  burn: "燃えるゴミ",
+  nonburn: "燃えないゴミ",
+  recycle: "資源ゴミ",
+  plastic: "プラスチック",
+  bottle: "ビン",
+  can: "缶",
+  paper: "古紙・ダンボール",
+  cloth: "古布・衣類",
+  oversized: "粗大ゴミ",
+  hazardous: "有害ゴミ",
+  battery: "乾電池",
+  other: "その他",
 };
 
 export const RULE_TYPE_LABELS: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Added 9 new icon categories (nonburn, plastic, can, paper, cloth, oversized, hazardous, battery, other) to support common Japanese waste classifications
- Updated ScheduleEditor dropdown to display Japanese labels instead of English keys for better UX
- Enhanced Gemini PDF parsing to auto-assign icons based on waste category names

## Test plan

- ✓ All linting, type checking, and tests pass (pnpm run check)
- ✓ Verify 12 icon options display with Japanese labels in Settings > Schedule Editor
- ✓ Test PDF import with Gemini to confirm icons are auto-assigned correctly
- ✓ Confirm dashboard displays all 12 icons properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)