### PR TITLE
Add eslint-plugin-testing-library

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import love from 'eslint-config-love';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import oxlint from 'eslint-plugin-oxlint';
+import testingLibrary from 'eslint-plugin-testing-library';
 
 export default [
   {
@@ -90,7 +91,9 @@ export default [
   ...oxlint.configs['flat/recommended'],
   {
     files: ['src/**/*.test.{ts,tsx}', 'src/**/__tests__/**/*.{ts,tsx}'],
+    ...testingLibrary.configs['flat/react'],
     rules: {
+      ...testingLibrary.configs['flat/react'].rules,
       '@typescript-eslint/no-magic-numbers': 'off',
       'max-lines-per-function': 'off',
       'unicorn/no-useless-undefined': 'off',

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-oxlint": "^1.0.0",
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-testing-library": "^7.16.0",
     "happy-dom": "^17.4.0",
     "oxfmt": "^0.22.0",
     "oxlint": "^1.37.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-testing-library:
+        specifier: ^7.16.0
+        version: 7.16.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
       happy-dom:
         specifier: ^17.4.0
         version: 17.6.3
@@ -1559,6 +1562,12 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-testing-library@7.16.0:
+    resolution: {integrity: sha512-lHZI6/Olb2oZqxd1+s1nOLCtL2PXKrc1ERz6oDbUKS0xZAMFH3Fy6wJo75z3pXTop3BV6+loPi2MSjIYt3vpAg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -4355,6 +4364,15 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-testing-library@7.16.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.56.0
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      eslint: 9.39.2(jiti@2.6.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint-scope@8.4.0:
     dependencies:

--- a/src/renderer/src/test/setup.ts
+++ b/src/renderer/src/test/setup.ts
@@ -1,6 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup } from "@testing-library/react";
-import { afterEach, vi } from "vitest";
+import { vi } from "vitest";
 
 vi.stubGlobal("electronAPI", {
   getSchedule: vi.fn().mockResolvedValue({ version: 2, entries: [] }),
@@ -10,8 +9,4 @@ vi.stubGlobal("electronAPI", {
   getApiKey: vi.fn().mockResolvedValue(null),
   setApiKey: vi.fn().mockResolvedValue(undefined),
   quit: vi.fn(),
-});
-
-afterEach(() => {
-  cleanup();
 });


### PR DESCRIPTION
## Summary

Add eslint-plugin-testing-library v7.16.0 to enforce Testing Library best practices across test files. The plugin's flat/react preset enables 21 rules including prefer-screen-queries, no-container, await-async-queries, and no-manual-cleanup.

Also remove manual cleanup() call from setup.ts since @testing-library/react automatically handles cleanup when Vitest's afterEach hook is available.

## Test plan

- [x] All 37 tests pass
- [x] No lint errors (existing warnings unrelated to this change)
- [x] Full CI check (`pnpm run check`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)